### PR TITLE
Fixing the defect with exp related to enchanting tables and improving the emergency stop command

### DIFF
--- a/src/main/java/com/bitquest/bitquest/BitQuest.java
+++ b/src/main/java/com/bitquest/bitquest/BitQuest.java
@@ -445,12 +445,31 @@ public class BitQuest extends JavaPlugin {
                 	return true;
                 }
                 if (cmd.getName().equalsIgnoreCase("emergencystop")) {
+                    ((Player) sender).kickPlayer("Test message");
                     Bukkit.shutdown();               
                     return true;
                 }            
             
             } else {
                 // PLAYER COMMANDS
+                if (cmd.getName().equalsIgnoreCase("emergencystop")) {
+                    StringBuilder message = new StringBuilder();
+                    message.append(sender.getName())
+                            .append(" has shut down the server for emergency reasons");
+                    
+                    if (args.length > 0) {
+                        message.append(": ");
+                        for (String word : args) {
+                            message.append(word).append(" ");
+                        }
+                    }
+                    for (Player currentPlayer : Bukkit.getOnlinePlayers()) {
+                        currentPlayer.kickPlayer(message.toString());
+                    }
+                    
+                    Bukkit.shutdown();               
+                    return true;
+                }
             }
         }
         return true;

--- a/src/main/java/com/bitquest/bitquest/BitQuest.java
+++ b/src/main/java/com/bitquest/bitquest/BitQuest.java
@@ -445,14 +445,6 @@ public class BitQuest extends JavaPlugin {
                 	return true;
                 }
                 if (cmd.getName().equalsIgnoreCase("emergencystop")) {
-                    ((Player) sender).kickPlayer("Test message");
-                    Bukkit.shutdown();               
-                    return true;
-                }            
-            
-            } else {
-                // PLAYER COMMANDS
-                if (cmd.getName().equalsIgnoreCase("emergencystop")) {
                     StringBuilder message = new StringBuilder();
                     message.append(sender.getName())
                             .append(" has shut down the server for emergency reasons");
@@ -469,7 +461,11 @@ public class BitQuest extends JavaPlugin {
                     
                     Bukkit.shutdown();               
                     return true;
-                }
+                }           
+            
+            } else {
+                // PLAYER COMMANDS
+
             }
         }
         return true;

--- a/src/main/java/com/bitquest/bitquest/EntityEvents.java
+++ b/src/main/java/com/bitquest/bitquest/EntityEvents.java
@@ -24,6 +24,8 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.enchantment.EnchantItemEvent;
 
 /**
  * Created by explodi on 11/7/15.
@@ -54,11 +56,22 @@ public class EntityEvents implements Listener {
         }
     }
 
+    
     @EventHandler
-    void onExperienceChange(PlayerExpChangeEvent event) throws ParseException, org.json.simple.parser.ParseException, IOException {
-
+    public void onExperienceChange(PlayerExpChangeEvent event) throws ParseException, org.json.simple.parser.ParseException, IOException {    
         event.setAmount(0);
         new User(event.getPlayer()).updateLevels();
+    }
+    
+    @EventHandler
+    public void onEnchantItemEvent(EnchantItemEvent event) throws ParseException, org.json.simple.parser.ParseException, IOException {
+        // Simply setting the cost to zero does not work. there are probably
+        // checks downstream for this. Instead cancel out the cost.
+        // None of this actually changes the bitquest xp anyway, so just make
+        // things look correct for the user. This only works for the enchantment table,
+        // not the anvil.
+        event.getEnchanter().setLevel(event.getEnchanter().getLevel() + event.getExpLevelCost());
+        
     }
 
     @EventHandler

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,4 +30,4 @@ commands:
     usage: /claim
   emergencystop:
     description: "Stops the server cleanly in case of emergency"
-    usage: /emergencystop    
+    usage: /emergencystop [reason]   


### PR DESCRIPTION
Players no longer see their exp level drop when using an enchantment table. I still need to make a similar fix for anvils.

The emergency stop command allows the user to specify their reasons for stopping the server now (optional). A generic message with those reasons added when present is displayed to each user on disconnect and that reason and event is added to the server logs.