### PR TITLE
EntityEvent (onPlayerLogin): Comment out println for status code.

### DIFF
--- a/src/main/java/com/bitquest/bitquest/EntityEvents.java
+++ b/src/main/java/com/bitquest/bitquest/EntityEvents.java
@@ -211,10 +211,11 @@ public class EntityEvents implements Listener {
             DataOutputStream wr = new DataOutputStream(con.getOutputStream());
             wr.flush();
             wr.close();
-            int responseCode = con.getResponseCode();
-            // System.out.println("\nSending 'POST' request to URL : " + url);
-            // System.out.println("Post parameters : " + urlParameters);
-            System.out.println("Response Code : " + responseCode);
+            
+            /*final int responseCode = con.getResponseCode();
+            System.out.println("\nSending 'POST' request to URL : " + url);
+            System.out.println("Post parameters : " + urlParameters);
+            System.out.println("Response Code : " + responseCode);*/
 
             BufferedReader in = new BufferedReader(
                     new InputStreamReader(con.getInputStream()));


### PR DESCRIPTION
Commented out your HTTP Status Code debugging, since you weren't using it. 

It'd probably be best in the future to check the status code for 404 or 429 (Rate Limit), which would require some threading to reschedule.