### PR TITLE
Issue 57: escape % signs to prevent chat breaking

### DIFF
--- a/src/main/java/com/bitquest/bitquest/ChatEvents.java
+++ b/src/main/java/com/bitquest/bitquest/ChatEvents.java
@@ -22,8 +22,9 @@ public class ChatEvents implements Listener {
 	@EventHandler
 	public void onChat(AsyncPlayerChatEvent event) {
 		
-		String message = event.getMessage();
+		String messageUnescaped = event.getMessage();
 		Player sender = event.getPlayer();
+		String message = messageUnescaped.replace("%%", "%%%%"); // escape any % signs to prevent a breakdown in chat script
 
 		if(message.startsWith("@")) {
 			event.setCancelled(true);


### PR DESCRIPTION
I haven't tested it, as I don't have docker. It's a pretty minor change though, but **please test it yourself to see if it works.**

Considering using "%%" in chat right now does actually escape, show a % on its own and fix the chat script from breaking and showing vanilla minecraft chat, this should work.

-CloakedSpartan