### PR TITLE
Suggest to the player how to shout

### DIFF
--- a/src/main/java/com/bitquest/bitquest/ChatEvents.java
+++ b/src/main/java/com/bitquest/bitquest/ChatEvents.java
@@ -77,6 +77,7 @@ public class ChatEvents implements Listener {
 			
 			if(recipients.size() <= 1) {
 				sender.sendMessage(ChatColor.BLUE + ChatColor.BOLD.toString() + "Local> " + ChatColor.RED + "Nobody is within earshot! Try shouting.");
+				sender.sendMessage(ChatColor.BLUE + ChatColor.BOLD.toString() + "Local> " + ChatColor.RED + "Shout by placing a ! before messages.");
 			} else {
 				for(Player recipient : recipients) {
 					recipient.sendMessage(event.getFormat());


### PR DESCRIPTION
Right now when a new player tries to talk and there isn't someone in range it simply tells them to "Try shouting.". This commit simply adds another line onto that, suggesting how to do it.

-CloakedSpartan