### PR TITLE
prevent naming of signs as "the wilderness"

### DIFF
--- a/src/main/java/com/bitquest/bitquest/SignEvents.java
+++ b/src/main/java/com/bitquest/bitquest/SignEvents.java
@@ -44,7 +44,7 @@ public class SignEvents implements Listener {
 
     			final String name = signText.substring(1,signText.length()-1);
 
-			if (name.equals("the wilderness")) {
+			if (name.equalsIgnoreCase("the wilderness")) {
 				player.sendMessage(ChatColor.RED + "You cannot name your land that.");
 				return;
 			}

--- a/src/main/java/com/bitquest/bitquest/SignEvents.java
+++ b/src/main/java/com/bitquest/bitquest/SignEvents.java
@@ -44,6 +44,10 @@ public class SignEvents implements Listener {
 
     			final String name = signText.substring(1,signText.length()-1);
 
+			if (name.equals("the wilderness")) {
+				player.sendMessage(ChatColor.RED + "You cannot name your land that.");
+				return;
+			}
     			if (bitQuest.REDIS.get("chunk" + x + "," + z + "owner") == null) {
     				final User user = new User(player);
     				player.sendMessage(ChatColor.YELLOW + "Claiming land...");


### PR DESCRIPTION
Prevents people from taking the grey colour of "the wilderness" (#56) by blocking it from being used as a name.

-CloakedSpartan