### PR TITLE
Added very demanded items to the Market Inventory.

### DIFF
--- a/src/main/java/com/bitquest/bitquest/InventoryEvents.java
+++ b/src/main/java/com/bitquest/bitquest/InventoryEvents.java
@@ -71,6 +71,7 @@ public class InventoryEvents implements Listener {
         trades.add(new Trade(new ItemStack(Material.SPONGE,8),20000));
         trades.add(new Trade(new ItemStack(Material.WOOD,64),20000));
         trades.add(new Trade(new ItemStack(Material.WOOL,64),20000));
+        trades.add(new Trade(new ItemStack(Material.PAPER,32),20000)) //needed
         trades.add(new Trade(new ItemStack(Material.BLAZE_ROD,16),30000));
         trades.add(new Trade(new ItemStack(Material.GOLD_INGOT,64),30000));
         trades.add(new Trade(new ItemStack(Material.GOLDEN_APPLE,6),30000));
@@ -79,11 +80,16 @@ public class InventoryEvents implements Listener {
         trades.add(new Trade(new ItemStack(Material.QUARTZ_BLOCK,64),30000));
         trades.add(new Trade(new ItemStack(Material.SEA_LANTERN,64),30000));
         trades.add(new Trade(new ItemStack(Material.GLOWSTONE,64),30000));
+        trades.add(new Trade(new ItemStack(Material.ANVIL, 1),30000));
+        trades.add(new Trade(new ItemStack(Material.ENDER_PEARL, 32),30000));
         trades.add(new Trade(new ItemStack(Material.EMERALD_BLOCK,32),35000));
+        trades.add(new Trade(new ItemStack(Material.NETHER_WARTS,16),40000));//Super demanded
         trades.add(new Trade(new ItemStack(Material.LAPIS_ORE,16),40000));
         trades.add(new Trade(new ItemStack(Material.SADDLE,1),50000)); //If we have a lot of horses in Satoshi, we want to ride them!
        // trades.add(new Trade(new ItemStack(Material.DIAMOND_HORSE_ARMOUR,1),55000)); //essential
+        trades.add(new Trade(new ItemStack(Material.SLIME_BALL,32),50000)); //Finally we add it.
         trades.add(new Trade(new ItemStack(Material.SHIELD,1),60000)); //epic
+        trades.add(new Trade(new ItemStack(Material.GOLDEN_APPLE,1,(short)6),60000)); //cool
         trades.add(new Trade(new ItemStack(Material.ELYTRA,1),100000));
 
 


### PR DESCRIPTION
Since the nether is blocked, Netherwart is very demanded in the server specially by pro players who farm bits the hardest. I propose to sell netherwart seeds, but without a very expensive price tag, so they also buy soul sand(already in the inventory) which is required to grow the netherwart.
Netherwart can't be crafted or taken from the nether, so 400 bits for 16 netherwart seeds looks very nice. Feel free to adjust it, 
400 + 200 from the soul sand = 600 bits to the loot wallet.

Also, so many people tell me that they are willing to pay anything to get notch apples because those cannot be crafted anymore. I propose to sell notch apples. 6 notch apples for 600 bits I think is fair enough: only 2 times the price of the normal golden apple and it recovers the loot wallet from 3 mob drops.

More:
-Added slime balls. This is probably the item that most people is currently interested in.
-Added paper. People that don't want to plant sugar canes inside their properties will buy this to make books and more.
-Added anvils.
-Added enderpearls.


Some issues: I've  found that notch apples in Bukkit are added like this-> Material.GOLDEN_APPLE, 1, (short)1; 
but I am not sure if the BitQuest plugin has tweaked that out. Please somebody check that out and make sure it is correct. We need notch apples in BitQuest! :)