### PR TITLE
Feature fix lost purchase

### DIFF
--- a/src/main/java/com/bitquest/bitquest/InventoryEvents.java
+++ b/src/main/java/com/bitquest/bitquest/InventoryEvents.java
@@ -96,7 +96,7 @@ public class InventoryEvents implements Listener {
         user.setTotalExperience(user.experience());
         // Merchant inventory
         if(inventory.getName().equalsIgnoreCase("Market")) {
-          if(event.getRawSlot() < event.getView().getTopInventory().getSize()) {
+            if(event.getRawSlot() < event.getView().getTopInventory().getSize()) {
                 final ItemStack clicked = event.getCurrentItem();
                 if(clicked!=null && clicked.getType()!=Material.AIR) {
                     BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
@@ -164,9 +164,9 @@ public class InventoryEvents implements Listener {
                     });
                 }
             
-          } else {
-            event.setCancelled(true);
-          }
+            } else {
+              event.setCancelled(true);
+            }
 
         } else if (inventory.getName().equals("Compass") && !player.hasMetadata("teleporting")) {
             final User bp = new User(player);

--- a/src/main/java/com/bitquest/bitquest/InventoryEvents.java
+++ b/src/main/java/com/bitquest/bitquest/InventoryEvents.java
@@ -120,10 +120,7 @@ public class InventoryEvents implements Listener {
                                 
                                 boolean hasOpenSlots = false;
                                 for (ItemStack item : player.getInventory().getContents()) {
-                                    if (item == null || (
-                                        item.getType() == clicked.getType() &&
-                                        item.stackSize + clicked.stackSize < item.getMaxStackSize()
-                                    )) {
+                                    if (item == null || (item.getType() == clicked.getType() && item.getAmount() + clicked.getAmount() < item.getMaxStackSize())) {
                                         hasOpenSlots = true;
                                         break;
                                     }

--- a/src/main/java/com/bitquest/bitquest/InventoryEvents.java
+++ b/src/main/java/com/bitquest/bitquest/InventoryEvents.java
@@ -120,7 +120,10 @@ public class InventoryEvents implements Listener {
                                 
                                 boolean hasOpenSlots = false;
                                 for (ItemStack item : player.getInventory().getContents()) {
-                                    if (item == null) {
+                                    if (item == null || (
+                                        item.getType() == clicked.getType() &&
+                                        item.stackSize + clicked.stackSize < item.getMaxStackSize()
+                                    )) {
                                         hasOpenSlots = true;
                                         break;
                                     }

--- a/src/main/java/com/bitquest/bitquest/InventoryEvents.java
+++ b/src/main/java/com/bitquest/bitquest/InventoryEvents.java
@@ -118,7 +118,10 @@ public class InventoryEvents implements Listener {
                                             sat = trades.get(i).price;
 
                                     }
-                                    if (sat > 10000 && user.wallet.transaction(sat, bitQuest.wallet) == true) {
+																		
+																		int openSlots = player.getInventory().getSize() - player.getInventory().getContents().length;
+																		
+                                    if (openSlots > 0 && sat > 10000 && user.wallet.transaction(sat, bitQuest.wallet) == true) {
                                         ItemStack item = event.getCurrentItem();
                                         ItemMeta meta = item.getItemMeta();
                                         ArrayList<String> Lore = new ArrayList<String>();
@@ -126,6 +129,7 @@ public class InventoryEvents implements Listener {
                                         item.setItemMeta(meta);
                                         player.getInventory().addItem(item);
                                         player.sendMessage(ChatColor.GREEN + "" + clicked.getType() + " purchased");
+																				
                                         if (bitQuest.messageBuilder != null) {
 
                                             // Create an event
@@ -140,7 +144,9 @@ public class InventoryEvents implements Listener {
                                         }
                                     } else {
                                         user.wallet.updateBalance();
-                                        if (user.wallet.balance != user.wallet.confirmedBalance) {
+                                        if (openSlots < 1) {
+																					player.sendMessage(ChatColor.RED + "You don't have any open slots in your inventory");
+																				} else if (user.wallet.balance != user.wallet.confirmedBalance) {
                                             player.sendMessage(ChatColor.RED + "Transaction failed (You have unconfirmed transactions. Please wait ~10 minutes and try again)");
                                         } else if(user.wallet.balance()<sat) {
                                             player.sendMessage(ChatColor.RED + "Transaction failed (Insufficient balance)");

--- a/src/main/java/com/bitquest/bitquest/InventoryEvents.java
+++ b/src/main/java/com/bitquest/bitquest/InventoryEvents.java
@@ -96,7 +96,7 @@ public class InventoryEvents implements Listener {
         user.setTotalExperience(user.experience());
         // Merchant inventory
         if(inventory.getName().equalsIgnoreCase("Market")) {
-        	if(event.getRawSlot() < event.getView().getTopInventory().getSize()) {
+          if(event.getRawSlot() < event.getView().getTopInventory().getSize()) {
                 final ItemStack clicked = event.getCurrentItem();
                 if(clicked!=null && clicked.getType()!=Material.AIR) {
                     BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
@@ -118,9 +118,9 @@ public class InventoryEvents implements Listener {
                                             sat = trades.get(i).price;
 
                                     }
-																		
-																		int openSlots = player.getInventory().getSize() - player.getInventory().getContents().length;
-																		
+                                    
+                                    int openSlots = player.getInventory().getSize() - player.getInventory().getContents().length;
+                                    
                                     if (openSlots > 0 && sat > 10000 && user.wallet.transaction(sat, bitQuest.wallet) == true) {
                                         ItemStack item = event.getCurrentItem();
                                         ItemMeta meta = item.getItemMeta();
@@ -129,7 +129,7 @@ public class InventoryEvents implements Listener {
                                         item.setItemMeta(meta);
                                         player.getInventory().addItem(item);
                                         player.sendMessage(ChatColor.GREEN + "" + clicked.getType() + " purchased");
-																				
+                                        
                                         if (bitQuest.messageBuilder != null) {
 
                                             // Create an event
@@ -145,8 +145,8 @@ public class InventoryEvents implements Listener {
                                     } else {
                                         user.wallet.updateBalance();
                                         if (openSlots < 1) {
-																					player.sendMessage(ChatColor.RED + "You don't have any open slots in your inventory");
-																				} else if (user.wallet.balance != user.wallet.confirmedBalance) {
+                                            player.sendMessage(ChatColor.RED + "You don't have any open slots in your inventory");
+                                        } else if (user.wallet.balance != user.wallet.confirmedBalance) {
                                             player.sendMessage(ChatColor.RED + "Transaction failed (You have unconfirmed transactions. Please wait ~10 minutes and try again)");
                                         } else if(user.wallet.balance()<sat) {
                                             player.sendMessage(ChatColor.RED + "Transaction failed (Insufficient balance)");
@@ -163,10 +163,10 @@ public class InventoryEvents implements Listener {
                         }
                     });
                 }
-        		
-        	} else {
-        		event.setCancelled(true);
-        	}
+            
+          } else {
+            event.setCancelled(true);
+          }
 
         } else if (inventory.getName().equals("Compass") && !player.hasMetadata("teleporting")) {
             final User bp = new User(player);


### PR DESCRIPTION
On a handful of occasions I've made purchases from villagers when I had no open inventory slots.  The purchased item effectively vanishes, but the account is still debited.  This patch checks the inventory for open slots before carrying out the transaction and, when no slots are available, alerts the user.