### PR TITLE
Allow mod's to rename claims

### DIFF
--- a/src/main/java/com/bitquest/bitquest/SignEvents.java
+++ b/src/main/java/com/bitquest/bitquest/SignEvents.java
@@ -104,7 +104,7 @@ public class SignEvents implements Listener {
     					}
     				});
 
-    			}else if (BitQuest.REDIS.get("chunk" + x + "," + z + "owner").equals(player.getUniqueId().toString())) {
+    			}else if (bitQuest.REDIS.get("chunk" + x + "," + z + "owner").equals(player.getUniqueId().toString()) || (bitQuest.isModerator(player)==true)) {
 					if (name.equals("abandon")) {
                         // Abandon land
                         BitQuest.REDIS.del("chunk" + x + "," + z + "owner");


### PR DESCRIPTION
Allow mod's to rename claims, regardless of owner.  Also allows mod's to transfer ownership of claims, and abandon claims belonging to perm. banned players