### PR TITLE
Add word filter for chat

### DIFF
--- a/src/main/java/com/bitquest/bitquest/BitQuest.java
+++ b/src/main/java/com/bitquest/bitquest/BitQuest.java
@@ -593,43 +593,47 @@ public class BitQuest extends JavaPlugin {
                     Set<String> filters = BitQuest.REDIS.smembers("filter"+player.getUniqueId().toString());
 
                     if (filters.size() > 0) {
-                        player.sendMessage("Your filtered words are:");
+                        player.sendMessage("Your filters are:");
                         for(String filter : filters) {
                             String[] split = filter.split("\\|");
                             player.sendMessage("  " + ChatColor.GOLD + split[0] + "  =>  " + split[1]);
                         }
                     } else {
-                        player.sendMessage("You don't have filtered words.");
+                        player.sendMessage("You haven't added any filters");
                     }
 
                     return true;
                 }
                 if (args.length >= 2) {
                     if (args[0].equalsIgnoreCase("add")) {
-                        String badWord = args[1];
+                        String badWord = args[1].replace("_" , " ");
                         String goodWord = "";
 
                         if (args.length >= 3) {
-                            goodWord = args[2];
+                            goodWord = args[2].replace("_" , " ");
                         } else {
                             for(int i = 0; i < badWord.length(); i ++) {
-                                goodWord += "*";
+                                if (badWord.charAt(i) != ' ') {
+                                    goodWord += "*";
+                                } else {
+                                    goodWord += " ";
+                                }
                             }
                         }
 
                         String filter = badWord + "|" + goodWord;
                         BitQuest.REDIS.sadd("filter" + player.getUniqueId().toString(), filter);
-                        sender.sendMessage(ChatColor.GREEN + "Filter for the word " + args[1] + " added.");
+                        sender.sendMessage(ChatColor.GREEN + "Filter for " + args[1] + " added.");
                         return true;
                     } else if (args[0].equalsIgnoreCase("remove")) {
-                        String badWord = args[1];
+                        String badWord = args[1].replace("_" , " ");
                         Set<String> filters = BitQuest.REDIS.smembers("filter"+player.getUniqueId().toString());
 
                         for (String filter : filters) {
                             String[] split = filter.split("\\|");
                             if (split[0].equals(badWord)) {
                                 BitQuest.REDIS.srem("filter" + player.getUniqueId().toString(), filter);
-                                player.sendMessage(ChatColor.GREEN + "The word " + badWord + " is not longer filtered.");
+                                player.sendMessage(ChatColor.GREEN + badWord + " is not longer filtered.");
                             }
                         }
 

--- a/src/main/java/com/bitquest/bitquest/BitQuest.java
+++ b/src/main/java/com/bitquest/bitquest/BitQuest.java
@@ -588,6 +588,56 @@ public class BitQuest extends JavaPlugin {
                 }
                 return false;
             }
+            if (cmd.getName().equalsIgnoreCase("filter")){
+                if (args.length == 0) {
+                    Set<String> filters = BitQuest.REDIS.smembers("filter"+player.getUniqueId().toString());
+
+                    if (filters.size() > 0) {
+                        player.sendMessage("Your filtered words are:");
+                        for(String filter : filters) {
+                            String[] split = filter.split("\\|");
+                            player.sendMessage("  " + ChatColor.GOLD + split[0] + "  =>  " + split[1]);
+                        }
+                    } else {
+                        player.sendMessage("You don't have filtered words.");
+                    }
+
+                    return true;
+                }
+                if (args.length >= 2) {
+                    if (args[0].equalsIgnoreCase("add")) {
+                        String badWord = args[1];
+                        String goodWord = "";
+
+                        if (args.length >= 3) {
+                            goodWord = args[2];
+                        } else {
+                            for(int i = 0; i < badWord.length(); i ++) {
+                                goodWord += "*";
+                            }
+                        }
+
+                        String filter = badWord + "|" + goodWord;
+                        BitQuest.REDIS.sadd("filter" + player.getUniqueId().toString(), filter);
+                        sender.sendMessage(ChatColor.GREEN + "Filter for the word " + args[1] + " added.");
+                        return true;
+                    } else if (args[0].equalsIgnoreCase("remove")) {
+                        String badWord = args[1];
+                        Set<String> filters = BitQuest.REDIS.smembers("filter"+player.getUniqueId().toString());
+
+                        for (String filter : filters) {
+                            String[] split = filter.split("\\|");
+                            if (split[0].equals(badWord)) {
+                                BitQuest.REDIS.srem("filter" + player.getUniqueId().toString(), filter);
+                                player.sendMessage(ChatColor.GREEN + "The word " + badWord + " is not longer filtered.");
+                            }
+                        }
+
+                        return true;
+                    }
+                }
+                return false;
+            }
             // MODERATOR COMMANDS
             if (isModerator(player)) {
                 // COMMAND: MOD

--- a/src/main/java/com/bitquest/bitquest/ChatEvents.java
+++ b/src/main/java/com/bitquest/bitquest/ChatEvents.java
@@ -2,6 +2,7 @@ package com.bitquest.bitquest;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -50,7 +51,7 @@ public class ChatEvents implements Listener {
 					sender.sendMessage(ChatColor.DARK_PURPLE + ChatColor.BOLD.toString() + "Clan> " + ChatColor.RED + "You have no online clanmates!");
 				} else {
 					for(Player teammate : teammates) {
-						teammate.sendMessage(event.getFormat());
+						teammate.sendMessage(filterWordsForPlayer(event.getFormat(), teammate));
 					}
 					System.out.println(ChatColor.stripColor(event.getFormat()));
 				}
@@ -63,7 +64,7 @@ public class ChatEvents implements Listener {
 				event.setCancelled(true);
 			}
 		} else {
-			event.setFormat(ChatColor.BLUE + ChatColor.BOLD.toString() + "Local> " + ChatColor.YELLOW + sender.getName() + " " + ChatColor.WHITE + message);
+			event.setFormat(ChatColor.BLUE + ChatColor.BOLD.toString() + "Local> " + ChatColor.YELLOW + sender.getName() + " " + ChatColor.WHITE + event.getMessage());
 			event.setCancelled(true);
 			Set<Player> recipients = new HashSet<Player>();
 			recipients.add(sender);
@@ -80,13 +81,26 @@ public class ChatEvents implements Listener {
 				sender.sendMessage(ChatColor.BLUE + ChatColor.BOLD.toString() + "Local> " + ChatColor.RED + "Shout by placing a ! before messages.");
 			} else {
 				for(Player recipient : recipients) {
-					recipient.sendMessage(event.getFormat());
+					recipient.sendMessage(filterWordsForPlayer(event.getFormat(), recipient));
 				}
 				System.out.println(ChatColor.stripColor(event.getFormat()));
 			}
 			
 		}
 		
+	}
+
+	private String filterWordsForPlayer(String msg, Player player) {
+		String newMsg = msg;
+		Set<String> words = BitQuest.REDIS.smembers("filter" + player.getUniqueId().toString());
+
+		for(String word : words) {
+			String[] split = word.split("\\|");
+			// Case insensitive replace
+			newMsg = newMsg.replaceAll("(?i)" + Pattern.quote(split[0]), split[1]);
+		}
+
+		return newMsg;
 	}
 	
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -37,3 +37,6 @@ commands:
   killAllVillagers:
     description: "Kills all the villagers"
     usage: "/killAllVillagers"
+  filter:
+    description: "Add a word to filter on the chat"
+    usage: "/filter <add|remove> <word to filter> [word to replace with]"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -38,5 +38,5 @@ commands:
     description: "Kills all the villagers"
     usage: "/killAllVillagers"
   filter:
-    description: "Add a word to filter on the chat"
+    description: "Add a filter to the chat. To include spaces use '_' instead.\nFor example: filter_this = filter this"
     usage: "/filter <add|remove> <word to filter> [word to replace with]"


### PR DESCRIPTION
Add a filter for chat words. #96 
Each player can decide which words to filter with the command
`/filter <add|remove> <word to filter> [optional word to replace with]`

The default replaced word is the same word in asterisks.