### PR TITLE
Public claim type. issue #34

### DIFF
--- a/src/main/java/com/bitquest/bitquest/BitQuest.java
+++ b/src/main/java/com/bitquest/bitquest/BitQuest.java
@@ -325,7 +325,10 @@ public class  BitQuest extends JavaPlugin {
         } else if (REDIS.get("chunk"+location.getChunk().getX()+","+location.getChunk().getZ()+"owner")!=null) {
             if (REDIS.get("chunk"+location.getChunk().getX()+","+location.getChunk().getZ()+"owner").equals(player.getUniqueId().toString())) {
                 return true;
-            } else {
+            } else if (REDIS.get("chunk"+location.getChunk().getX()+","+location.getChunk().getZ()+"name").endsWith("*P*")) {
+                //is public shared
+               return true;    
+	    } else {
                 return false;
             }
         } else {

--- a/src/main/java/com/bitquest/bitquest/BitQuest.java
+++ b/src/main/java/com/bitquest/bitquest/BitQuest.java
@@ -325,7 +325,7 @@ public class  BitQuest extends JavaPlugin {
         } else if (REDIS.get("chunk"+location.getChunk().getX()+","+location.getChunk().getZ()+"owner")!=null) {
             if (REDIS.get("chunk"+location.getChunk().getX()+","+location.getChunk().getZ()+"owner").equals(player.getUniqueId().toString())) {
                 return true;
-            } else if (REDIS.get("chunk"+location.getChunk().getX()+","+location.getChunk().getZ()+"name").endsWith("*P*")) {
+            } else if (REDIS.get("chunk"+location.getChunk().getX()+","+location.getChunk().getZ()+"name").endsWith("*P")) {
                 //is public shared
                return true;    
 	    } else {


### PR DESCRIPTION


RE: issue #34

Allows making chunk public ( for community builds, public farms etc. ) while retaining ownership

Usage: adding *P to end of name on sign ( ^land_name *P^ ) enables sharing,
placing rename sign without *P ( ^land_name^ ) removes sharing again
