### PR TITLE
Replace '%' sings to prevent chat script breakdown.

### DIFF
--- a/src/main/java/com/bitquest/bitquest/ChatEvents.java
+++ b/src/main/java/com/bitquest/bitquest/ChatEvents.java
@@ -24,7 +24,7 @@ public class ChatEvents implements Listener {
 		
 		String messageUnescaped = event.getMessage();
 		Player sender = event.getPlayer();
-		String message = messageUnescaped.replace("%%", "%%%%"); // escape any % signs to prevent a breakdown in chat script
+		String message = messageUnescaped.replace("%", "％"); // escape any % signs to prevent a breakdown in chat script
 
 		if(message.startsWith("@")) {
 			event.setCancelled(true);


### PR DESCRIPTION
Use Unicode Character 'FULLWIDTH PERCENT SIGN' (U+FF05) ％ instead.