### PR TITLE
EntityEvent: useRandomEquipment() - Fix Useless Object Init & Reduce Enchanting Code Reuse

### DIFF
--- a/src/main/java/com/bitquest/bitquest/EntityEvents.java
+++ b/src/main/java/com/bitquest/bitquest/EntityEvents.java
@@ -621,73 +621,81 @@ public class EntityEvents implements Listener {
 
         // Gives random SWORD
         if (BitQuest.rand(0, 32) < level && !(entity instanceof Skeleton)) {
-            ItemStack sword = new ItemStack(Material.WOODEN_DOOR);
-            if (BitQuest.rand(0, 128) < level) sword = new ItemStack(Material.WOODEN_DOOR);
-            if (BitQuest.rand(0, 128) < level) sword = new ItemStack(Material.IRON_AXE);
-            if (BitQuest.rand(0, 128) < level) sword = new ItemStack(Material.WOOD_SWORD);
-            if (BitQuest.rand(0, 128) < level) sword = new ItemStack(Material.IRON_SWORD);
-            if (BitQuest.rand(0, 128) < level) sword = new ItemStack(Material.DIAMOND_SWORD);
+            Material material = Material.WOODEN_DOOR;
+            if (BitQuest.rand(0, 128) < level) material = Material.IRON_AXE;
+            if (BitQuest.rand(0, 128) < level) material = Material.WOOD_SWORD;
+            if (BitQuest.rand(0, 128) < level) material = Material.IRON_SWORD;
+            if (BitQuest.rand(0, 128) < level) material = Material.DIAMOND_SWORD;
+            ItemStack sword = new ItemStack(material);
 
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(sword);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(sword);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(sword);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(sword);
+            for(short i = 0; i < 4; i++){
+                if (BitQuest.rand(0, 128) < level)
+                    randomEnchantItem(sword);
+            }
 
             entity.getEquipment().setItemInHand(sword);
         }
 
         // Gives random HELMET
         if (BitQuest.rand(0, 32) < level) {
-            ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
-            if (BitQuest.rand(0, 128) < level) helmet = new ItemStack(Material.CHAINMAIL_HELMET);
-            if (BitQuest.rand(0, 128) < level) helmet = new ItemStack(Material.IRON_HELMET);
-            if (BitQuest.rand(0, 128) < level) helmet = new ItemStack(Material.DIAMOND_HELMET);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(helmet);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(helmet);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(helmet);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(helmet);
+            Material material = Material.LEATHER_HELMET;
+            if (BitQuest.rand(0, 128) < level) material = Material.CHAINMAIL_HELMET;
+            if (BitQuest.rand(0, 128) < level) material = Material.IRON_HELMET;
+            if (BitQuest.rand(0, 128) < level) material = Material.DIAMOND_HELMET;
+            ItemStack helmet = new ItemStack(material);
+
+            for(short i = 0; i < 4; i++){
+                if (BitQuest.rand(0, 128) < level)
+                    randomEnchantItem(helmet);
+            }
 
             entity.getEquipment().setHelmet(helmet);
         }
 
         // Gives random CHESTPLATE
         if (BitQuest.rand(0, 32) < level) {
-            ItemStack chest = new ItemStack(Material.LEATHER_CHESTPLATE);
-            if (BitQuest.rand(0, 128) < level) chest = new ItemStack(Material.CHAINMAIL_CHESTPLATE);
-            if (BitQuest.rand(0, 128) < level) chest = new ItemStack(Material.IRON_CHESTPLATE);
-            if (BitQuest.rand(0, 128) < level) chest = new ItemStack(Material.DIAMOND_CHESTPLATE);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(chest);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(chest);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(chest);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(chest);
+            Material material = Material.LEATHER_CHESTPLATE;
+            if (BitQuest.rand(0, 128) < level) material = Material.CHAINMAIL_CHESTPLATE;
+            if (BitQuest.rand(0, 128) < level) material = Material.IRON_CHESTPLATE;
+            if (BitQuest.rand(0, 128) < level) material = Material.DIAMOND_CHESTPLATE;
+            ItemStack chest = new ItemStack(material);
+
+            for(short i = 0; i < 4; i++) {
+                if (BitQuest.rand(0, 128) < level)
+                    randomEnchantItem(chest);
+            }
 
             entity.getEquipment().setChestplate(chest);
         }
 
         // Gives random Leggings
         if (BitQuest.rand(0, 128) < level) {
-            ItemStack leggings = new ItemStack(Material.LEATHER_LEGGINGS);
-            if (BitQuest.rand(0, 128) < level) leggings = new ItemStack(Material.CHAINMAIL_LEGGINGS);
-            if (BitQuest.rand(0, 128) < level) leggings = new ItemStack(Material.IRON_LEGGINGS);
-            if (BitQuest.rand(0, 128) < level) leggings = new ItemStack(Material.DIAMOND_LEGGINGS);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(leggings);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(leggings);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(leggings);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(leggings);
+            Material material = Material.LEATHER_LEGGINGS;
+            if (BitQuest.rand(0, 128) < level) material = Material.CHAINMAIL_LEGGINGS;
+            if (BitQuest.rand(0, 128) < level) material = Material.IRON_LEGGINGS;
+            if (BitQuest.rand(0, 128) < level) material = Material.DIAMOND_LEGGINGS;
+            ItemStack leggings = new ItemStack(material);
+
+            for(short i = 0; i < 4; i++) {
+                if (BitQuest.rand(0, 128) < level)
+                    randomEnchantItem(leggings);
+            }
 
             entity.getEquipment().setLeggings(leggings);
         }
 
         // Gives Random BOOTS
         if (BitQuest.rand(0, 128) < level) {
-            ItemStack boots = new ItemStack(Material.LEATHER_BOOTS);
-            if (BitQuest.rand(0, 128) < level) boots = new ItemStack(Material.CHAINMAIL_BOOTS);
-            if (BitQuest.rand(0, 128) < level) boots = new ItemStack(Material.IRON_BOOTS);
-            if (BitQuest.rand(0, 128) < level) boots = new ItemStack(Material.DIAMOND_BOOTS);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(boots);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(boots);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(boots);
-            if (BitQuest.rand(0, 128) < level) randomEnchantItem(boots);
+            Material material = Material.LEATHER_BOOTS;
+            if (BitQuest.rand(0, 128) < level) material = Material.CHAINMAIL_BOOTS;
+            if (BitQuest.rand(0, 128) < level) material = Material.IRON_BOOTS;
+            if (BitQuest.rand(0, 128) < level) material = Material.DIAMOND_BOOTS;
+            ItemStack boots = new ItemStack(material);
+
+            for(short i = 0; i < 4; i++) {
+                if (BitQuest.rand(0, 128) < level)
+                    randomEnchantItem(boots);
+            }
 
             entity.getEquipment().setBoots(boots);
         }


### PR DESCRIPTION
* Changes the item randomization to just use the enum, instead of having the possibility of generating multiple class instances that won't be used, since only the last one one actually matters. This maintains the original logic.
* Changes the duplicate item enchant calls to a simple for loop.