### PR TITLE
Remove empty clans

### DIFF
--- a/src/main/java/com/bitquest/bitquest/BitQuest.java
+++ b/src/main/java/com/bitquest/bitquest/BitQuest.java
@@ -198,6 +198,8 @@ public class  BitQuest extends JavaPlugin {
         modCommands.put("banlist", new BanlistCommand());
         modCommands.put("spectate", new SpectateCommand(this));
         modCommands.put("emergencystop", new EmergencystopCommand());
+        // TODO: Remove this command after migrate.
+        modCommands.put("migrateclans", new MigrateClansCommand());
         sendDiscordMessage("bitquest started");
     }
     // @todo: make this just accept the endpoint name and (optional) parameters

--- a/src/main/java/com/bitquest/bitquest/commands/ClanCommand.java
+++ b/src/main/java/com/bitquest/bitquest/commands/ClanCommand.java
@@ -24,6 +24,7 @@ public class ClanCommand extends CommandAction {
                                 if (!BitQuest.REDIS.sismember("clans", clanName)) {
                                     BitQuest.REDIS.sadd("clans", clanName);
                                     BitQuest.REDIS.set("clan:" + player.getUniqueId().toString(), clanName);
+                                    BitQuest.REDIS.sadd("clan:" + clanName + ":members", player.getUniqueId().toString());
                                     player.sendMessage(ChatColor.GREEN + "Congratulations! you are the founder of the " + clanName + " clan");
                                     player.setPlayerListName(ChatColor.GOLD + "[" + clanName + "] " + ChatColor.WHITE + player.getName());
                                     return true;
@@ -113,6 +114,7 @@ public class ClanCommand extends CommandAction {
                             // user is not part of any clan
                             BitQuest.REDIS.srem("invitations:" + clanName, player.getUniqueId().toString());
                             BitQuest.REDIS.set("clan:" + player.getUniqueId().toString(), clanName);
+                            BitQuest.REDIS.sadd("clan:" + clanName + ":members", player.getUniqueId().toString());
                             player.sendMessage(ChatColor.GREEN + "You are now part of the " + clanName + " clan!");
                             player.setPlayerListName(ChatColor.GOLD + "[" + clanName + "] " + ChatColor.WHITE + player.getName());
                             return true;
@@ -141,6 +143,8 @@ public class ClanCommand extends CommandAction {
                             // check that kicker and player are in the same clan
                             if (BitQuest.REDIS.get("clan:" + uuid).equals(clan)) {
                                 BitQuest.REDIS.del("clan:" + uuid);
+                                BitQuest.REDIS.srem("clan:" + clan + ":members", uuid);
+                                removeEmptyClan(clan);
                                 player.sendMessage(ChatColor.GREEN + "Player " + toKick + " was kicked from the " + clan + " clan.");
                                 if (Bukkit.getPlayerExact(toKick) != null) {
                                     Player invitedPlayer = Bukkit.getPlayerExact(toKick);
@@ -168,11 +172,14 @@ public class ClanCommand extends CommandAction {
             }
             if (subCommand.equals("leave")) {
                 if (BitQuest.REDIS.exists("clan:" + player.getUniqueId().toString())) {
-                    // TODO: when a clan gets emptied, should be removed from the "clans" set
-                    player.sendMessage(ChatColor.GREEN + "You are no longer part of the " + BitQuest.REDIS.get("clan:" + player.getUniqueId().toString()) + " clan");
+                    String clan = BitQuest.REDIS.get("clan:" + player.getUniqueId().toString());
+                    player.sendMessage(ChatColor.GREEN + "You are no longer part of the " + clan + " clan");
                     BitQuest.REDIS.del("clan:" + player.getUniqueId().toString());
+                    BitQuest.REDIS.srem("clan:" + clan + ":members", player.getUniqueId().toString());
 
                     player.setPlayerListName(player.getName());
+
+                    removeEmptyClan(clan);
                     return true;
                 } else {
                     player.sendMessage(ChatColor.RED + "You don't belong to a clan.");
@@ -184,5 +191,12 @@ public class ClanCommand extends CommandAction {
             return true;
         }
         return false;
+    }
+
+    private void removeEmptyClan(String clan) {
+        if (BitQuest.REDIS.scard("clan:" + clan + ":members") == 0) {
+            BitQuest.REDIS.del("clan:" + clan + ":members");
+            BitQuest.REDIS.srem("clans", clan);
+        }
     }
 }

--- a/src/main/java/com/bitquest/bitquest/commands/ClanCommand.java
+++ b/src/main/java/com/bitquest/bitquest/commands/ClanCommand.java
@@ -197,6 +197,7 @@ public class ClanCommand extends CommandAction {
         if (BitQuest.REDIS.scard("clan:" + clan + ":members") == 0) {
             BitQuest.REDIS.del("clan:" + clan + ":members");
             BitQuest.REDIS.srem("clans", clan);
+            BitQuest.REDIS.del("invitations:" + clan);
         }
     }
 }

--- a/src/main/java/com/bitquest/bitquest/commands/MigrateClansCommand.java
+++ b/src/main/java/com/bitquest/bitquest/commands/MigrateClansCommand.java
@@ -1,0 +1,59 @@
+package com.bitquest.bitquest.commands;
+
+import com.bitquest.bitquest.BitQuest;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+
+import java.util.*;
+
+public class MigrateClansCommand extends CommandAction {
+    public boolean run(CommandSender sender, Command cmd, String label, String[] args, Player player) {
+        List<String> clans = new ArrayList<String>(BitQuest.REDIS.smembers("clans"));
+        Map<String, List<String>> clansMembers = new HashMap<String, List<String>>();
+
+        ScanParams scanParams = new ScanParams();
+        scanParams.match("clan:*[^:members]");
+        String cursor = ScanParams.SCAN_POINTER_START;
+
+        do {
+            ScanResult<String> scanResult = BitQuest.REDIS.scan(cursor, scanParams);
+            List<String> result = scanResult.getResult();
+
+            for (String key : result) {
+                String clan = BitQuest.REDIS.get(key);
+                if (!clansMembers.containsKey(clan)) {
+                    clansMembers.put(clan, new ArrayList<String>());
+                }
+
+                String uuid = key.split(":")[1];
+                clansMembers.get(clan).add(uuid);
+            }
+            
+            cursor = scanResult.getStringCursor();
+        } while(!cursor.equals(ScanParams.SCAN_POINTER_START));
+
+        for (String clan : clans) {
+            if (!clansMembers.containsKey(clan)) {
+                BitQuest.REDIS.srem("clans", clan);
+                BitQuest.REDIS.del("invitations:" + clan);
+                player.sendMessage("Clan " + clan + " is empty. Deleted");
+            }
+        }
+
+        for (Map.Entry<String, List<String>> entry : clansMembers.entrySet()) {
+            String clan = entry.getKey();
+            for (String member : entry.getValue()) {
+                player.sendMessage(ChatColor.YELLOW + "Player " + member + " added to clan " + clan);
+                BitQuest.REDIS.sadd("clan:" + clan + ":members", member);
+            }
+        }
+
+        player.sendMessage(ChatColor.GREEN + "Clans migrated. ");
+
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -61,3 +61,6 @@ commands:
   donate:
     description: "Donate to BitQuest from your wallet"
     usage: "/donate <amount>"
+  migrateclans:
+    description: "Migrate clans to keep track of members"
+    usage: "/migrateclans"


### PR DESCRIPTION
This creates a new set in REDIS `clan:clanname:members` that holds a list of members
When `clan:clanname:members` is empty the clan is deleted.

Also adds the command /migrateclans to remove old empty clans and add a list of members of active clans.
#139 
  