### PR TITLE
Emerald loot fix? and piston nether fix. and currency command modification

### DIFF
--- a/src/main/java/com/bitquest/bitquest/commands/CurrencyCommand.java
+++ b/src/main/java/com/bitquest/bitquest/commands/CurrencyCommand.java
@@ -29,14 +29,14 @@ public class CurrencyCommand extends CommandAction {
 			player.sendMessage(ChatColor.GREEN+"Currency changed to " + BitQuest.REDIS.get("currency"+player.getUniqueId().toString()));                        
 
 				}
-			else if((args[0].equalsIgnoreCase("btc"))||(args[0].equalsIgnoreCase("bitcoin"))||(args[0].equalsIgnoreCase(BitQuest.DENOMINATION_NAME))) {
+			else if(args[0].equalsIgnoreCase(BitQuest.DENOMINATION_NAME)) {
 				BitQuest.REDIS.set("currency"+player.getUniqueId().toString(), BitQuest.DENOMINATION_NAME);
 				player.sendMessage(ChatColor.GREEN+"Currency changed to " + BitQuest.REDIS.get("currency"+player.getUniqueId().toString()));
 	                               						   
 			} else {
                     player.sendMessage(ChatColor.RED+"There was a problem changing your currency.");
                 } 
-		try { bitQuest.updateScoreboard(player); } catch (Exception e){}
+		try { bitQuest.updateScoreboard(player); } catch (Exception e){e.printStackTrace();}
 		return true; 	
 		}
 		return false; 	

--- a/src/main/java/com/bitquest/bitquest/events/BlockEvents.java
+++ b/src/main/java/com/bitquest/bitquest/events/BlockEvents.java
@@ -46,8 +46,6 @@ public class BlockEvents implements Listener {
     Block b = event.getBlock();
     Material m = b.getType();
     if (m.equals(Material.BEDROCK)
-        || m.equals(Material.END_BRICKS)
-        || m.equals(Material.ENDER_STONE)
         || m.equals(Material.COMMAND)
         || m.equals(Material.COMMAND_CHAIN)
         || m.equals(Material.COMMAND_REPEATING)) {
@@ -87,6 +85,14 @@ public class BlockEvents implements Listener {
     List<Block> blocks = event.getBlocks();
     BlockFace direction = event.getDirection();
 
+	String tempchunk="";
+	if (event.getBlock().getLocation().getWorld().getName().equals("world")){
+        tempchunk="chunk";
+	}//end world lmao @bitcoinjake09
+	else if (event.getBlock().getLocation().getWorld().getName().equals("world_nether")){
+	tempchunk="netherchunk";
+	}//end nether @bitcoinjake09
+
     if (!blocks.isEmpty()) {
       Block lastBlock = blocks.get(blocks.size() - 1);
       Block nextBlock = lastBlock.getRelative(direction);
@@ -96,11 +102,11 @@ public class BlockEvents implements Listener {
 
       String owner1, owner2;
       if ((owner2 =
-              BitQuest.REDIS.get("chunk" + blockChunk.getX() + "," + blockChunk.getZ() + "owner"))
+              BitQuest.REDIS.get(tempchunk+"" + blockChunk.getX() + "," + blockChunk.getZ() + "owner"))
           != null) {
         if ((owner1 =
                 BitQuest.REDIS.get(
-                    "chunk" + pistonChunk.getX() + "," + pistonChunk.getZ() + "owner"))
+                    tempchunk+"" + pistonChunk.getX() + "," + pistonChunk.getZ() + "owner"))
             != null) {
           if (!owner1.equals(owner2)) {
             event.setCancelled(true);
@@ -117,6 +123,13 @@ public class BlockEvents implements Listener {
     Block piston = event.getBlock();
     BlockFace direction = event.getDirection();
     Block nextBlock = piston.getRelative(direction, -2); // Direction is inverted?
+	String tempchunk="";
+	if (event.getBlock().getLocation().getWorld().getName().equals("world")){
+        tempchunk="chunk";
+	}//end world lmao @bitcoinjake09
+	else if (event.getBlock().getLocation().getWorld().getName().equals("world_nether")){
+	tempchunk="netherchunk";
+	}//end nether @bitcoinjake09
 
     if (event.isSticky()) {
       Chunk pistonChunk = piston.getChunk();
@@ -124,11 +137,11 @@ public class BlockEvents implements Listener {
 
       String owner1, owner2;
       if ((owner2 =
-              BitQuest.REDIS.get("chunk" + blockChunk.getX() + "," + blockChunk.getZ() + "owner"))
+              BitQuest.REDIS.get(tempchunk+"" + blockChunk.getX() + "," + blockChunk.getZ() + "owner"))
           != null) {
         if ((owner1 =
                 BitQuest.REDIS.get(
-                    "chunk" + pistonChunk.getX() + "," + pistonChunk.getZ() + "owner"))
+                    tempchunk+"" + pistonChunk.getX() + "," + pistonChunk.getZ() + "owner"))
             != null) {
           if (!owner1.equals(owner2)) {
             event.setCancelled(true);


### PR DESCRIPTION
seems like emeralds work like this? ill send explodi a confirmation picture.

added nether support for pistons

took out "bits & bitcoin" from currency command, so it works dynamically over doge/bits or whatever and not be funny like be on DQ and say "/currency bitcoin" and it changes your currency to doge :p so fixed...

also updated pvp call in entityevents so its smaller...